### PR TITLE
feat[#73]: install ts-node, fix various typing errors around audio manager

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,15 @@
     "@typescript-eslint/no-floating-promises": "warn",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-use-before-define": "error",
-    "import/extensions": ["error", "never"],
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "js": "always",
+        "ts": "never",
+        "tsx": "never"
+      }
+    ],
     "import/no-unresolved": "off",
     "no-shadow": "off",
     "no-use-before-define": "off",
@@ -39,5 +47,12 @@
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
     "react/require-default-props": "off"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".ts", ".tsx"]
+      }
+    }
   }
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,4 +5,5 @@ export default {
   coverageDirectory: "coverage",
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,4 +6,7 @@ export default {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+  moduleNameMapper: {
+    "^@src/(.*)\\.js$": "<rootDir>/src/$1.ts",
+  },
 };

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "rimraf": "^5.0.0",
     "semantic-release": "^21.0.2",
     "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
     "typescript": "^5.0.4"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         version: 8.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+        version: 29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -107,7 +107,10 @@ importers:
         version: 21.0.2(typescript@5.0.4)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)))(typescript@5.0.4)
+        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)))(typescript@5.0.4)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -347,7 +350,7 @@ packages:
     engines: {node: '>=v14'}
 
   '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==, tarball: https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz}
     engines: {node: '>=12'}
 
   '@eslint-community/eslint-utils@4.4.0':
@@ -465,11 +468,6 @@ packages:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==, tarball: https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/resolve-uri@https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz':
-    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==, tarball: https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz}
-    version: 3.1.0
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/set-array@1.2.1':
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==, tarball: https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz}
     engines: {node: '>=6.0.0'}
@@ -477,16 +475,11 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.14':
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==, tarball: https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz}
 
-  '@jridgewell/sourcemap-codec@https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz':
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==, tarball: https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz}
-    version: 1.4.14
-
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==, tarball: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz}
 
-  '@jridgewell/trace-mapping@https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz':
+  '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==, tarball: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz}
-    version: 0.3.9
 
   '@mole-inc/bin-wrapper@8.0.1':
     resolution: {integrity: sha512-sTGoeZnjI8N4KS+sW2AN95gDBErhAguvkw/tWdCjeM8bvxpz5lqrnd0vOJABA1A+Ic3zED7PYoLP/RANLgVotA==}
@@ -735,16 +728,16 @@ packages:
     engines: {node: '>= 10'}
 
   '@tsconfig/node10@1.0.9':
-    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==, tarball: https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz}
 
   '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==, tarball: https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz}
 
   '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==, tarball: https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz}
 
   '@tsconfig/node16@1.0.3':
-    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==, tarball: https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==, tarball: https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz}
@@ -914,17 +907,11 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn-walk@8.2.0:
-    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==, tarball: https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz}
     engines: {node: '>=0.4.0'}
 
   acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==, tarball: https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz}
-    version: 8.8.2
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -991,7 +978,7 @@ packages:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
 
   arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==, tarball: https://registry.npmjs.org/arg/-/arg-4.1.3.tgz}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==, tarball: https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz}
@@ -1391,7 +1378,7 @@ packages:
     hasBin: true
 
   create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==, tarball: https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz}
 
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -1546,7 +1533,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==, tarball: https://registry.npmjs.org/diff/-/diff-4.0.2.tgz}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -4219,8 +4206,8 @@ packages:
       esbuild:
         optional: true
 
-  ts-node@10.9.1:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==, tarball: https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz}
     hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
@@ -4352,7 +4339,7 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==, tarball: https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==, tarball: https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz}
@@ -4519,7 +4506,7 @@ packages:
     engines: {node: '>=12'}
 
   yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==, tarball: https://registry.npmjs.org/yn/-/yn-3.1.1.tgz}
     engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
@@ -4799,12 +4786,12 @@ snapshots:
       '@types/node': 14.18.34
       chalk: 4.1.2
       cosmiconfig: 8.1.3
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@14.18.34)(cosmiconfig@8.1.3)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))(typescript@5.0.4)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@14.18.34)(cosmiconfig@8.1.3)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))(typescript@5.0.4)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@swc/core@1.3.57)(@types/node@14.18.34)(typescript@5.0.4)
+      ts-node: 10.9.2(@swc/core@1.3.57)(@types/node@14.18.34)(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -4828,8 +4815,7 @@ snapshots:
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
-      '@jridgewell/trace-mapping': https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz
-    optional: true
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.40.0)':
     dependencies:
@@ -4894,7 +4880,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -4908,7 +4894,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+      jest-config: 29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -5055,26 +5041,19 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.0': {}
 
-  '@jridgewell/resolve-uri@https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz':
-    optional: true
-
   '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/sourcemap-codec@1.4.14': {}
-
-  '@jridgewell/sourcemap-codec@https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz':
-    optional: true
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
 
-  '@jridgewell/trace-mapping@https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz':
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
-      '@jridgewell/resolve-uri': https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz
-      '@jridgewell/sourcemap-codec': https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz
-    optional: true
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
 
   '@mole-inc/bin-wrapper@8.0.1':
     dependencies:
@@ -5372,17 +5351,13 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@tsconfig/node10@1.0.9':
-    optional: true
+  '@tsconfig/node10@1.0.9': {}
 
-  '@tsconfig/node12@1.0.11':
-    optional: true
+  '@tsconfig/node12@1.0.11': {}
 
-  '@tsconfig/node14@1.0.3':
-    optional: true
+  '@tsconfig/node14@1.0.3': {}
 
-  '@tsconfig/node16@1.0.3':
-    optional: true
+  '@tsconfig/node16@1.0.3': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -5594,9 +5569,6 @@ snapshots:
 
   acorn@8.8.2: {}
 
-  acorn@https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz:
-    optional: true
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.3.4
@@ -5663,8 +5635,7 @@ snapshots:
 
   arch@2.2.0: {}
 
-  arg@4.1.3:
-    optional: true
+  arg@4.1.3: {}
 
   argparse@1.0.10:
     dependencies:
@@ -6099,11 +6070,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@4.3.0(@types/node@14.18.34)(cosmiconfig@8.1.3)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))(typescript@5.0.4):
+  cosmiconfig-typescript-loader@4.3.0(@types/node@14.18.34)(cosmiconfig@8.1.3)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))(typescript@5.0.4):
     dependencies:
       '@types/node': 14.18.34
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)
+      ts-node: 10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)
       typescript: 5.0.4
     optional: true
 
@@ -6114,13 +6085,13 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
 
-  create-jest@29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)):
+  create-jest@29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+      jest-config: 29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -6129,8 +6100,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-require@1.1.1:
-    optional: true
+  create-require@1.1.1: {}
 
   cross-env@7.0.3:
     dependencies:
@@ -6276,8 +6246,7 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2:
-    optional: true
+  diff@4.0.2: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -7589,16 +7558,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)):
+  jest-cli@29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+      create-jest: 29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+      jest-config: 29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -7608,7 +7577,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)):
+  jest-config@29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -7634,7 +7603,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.11.14
-      ts-node: 10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)
+      ts-node: 10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -7869,12 +7838,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)):
+  jest@29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+      jest-cli: 29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9216,12 +9185,12 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
-  ts-jest@29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)))(typescript@5.0.4):
+  ts-jest@29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4)))(typescript@5.0.4):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.11.14)(ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
+      jest: 29.7.0(@types/node@18.11.14)(ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -9235,7 +9204,7 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.25.2)
 
-  ts-node@10.9.1(@swc/core@1.3.57)(@types/node@14.18.34)(typescript@5.0.4):
+  ts-node@10.9.2(@swc/core@1.3.57)(@types/node@14.18.34)(typescript@5.0.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -9243,7 +9212,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 14.18.34
-      acorn: https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -9256,7 +9225,7 @@ snapshots:
       '@swc/core': 1.3.57
     optional: true
 
-  ts-node@10.9.1(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4):
+  ts-node@10.9.2(@swc/core@1.3.57)(@types/node@18.11.14)(typescript@5.0.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -9264,7 +9233,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.11.14
-      acorn: https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -9275,7 +9244,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.3.57
-    optional: true
 
   tsconfig-paths@3.14.2:
     dependencies:
@@ -9382,8 +9350,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  v8-compile-cache-lib@3.0.1:
-    optional: true
+  v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -9550,8 +9517,7 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yn@3.1.1:
-    optional: true
+  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/useAudioManager.test.tsx
+++ b/src/useAudioManager.test.tsx
@@ -2,7 +2,8 @@
 import React from "react";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { render, act } from "@testing-library/react";
-import { AudioManagerProvider, useAudioManager } from "./useAudioManager.js";
+// eslint-disable-next-line import/extensions
+import { AudioManagerProvider, useAudioManager } from "./useAudioManager.tsx";
 
 // Mock AudioManager class
 jest.mock("@charisma-ai/sdk", () => ({

--- a/src/useAudioManager.tsx
+++ b/src/useAudioManager.tsx
@@ -18,7 +18,7 @@ import {
   AudioManagerConnectionError,
   AudioManagerInitialisationError,
   AudioPlaybackError,
-} from "./errors/AudioManagerErrors";
+} from "@src/errors/AudioManagerErrors.js";
 
 type AudioManagerContextType = {
   isListening: boolean;

--- a/src/useAudioManager.tsx
+++ b/src/useAudioManager.tsx
@@ -18,7 +18,7 @@ import {
   AudioManagerConnectionError,
   AudioManagerInitialisationError,
   AudioPlaybackError,
-} from "./errors/AudioManagerErrors.js";
+} from "./errors/AudioManagerErrors";
 
 type AudioManagerContextType = {
   isListening: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "sourceMap": true,
     "strict": true,
     "target": "esnext",
-    "types": ["jest", "@testing-library/jest-dom"]
+    "types": ["jest", "@testing-library/jest-dom"],
+    "allowImportingTsExtensions": true,
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,11 @@
     "target": "esnext",
     "types": ["jest", "@testing-library/jest-dom"],
     "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "baseUrl": ".",
+    "paths": {
+      "@src/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
- Import ts-node to allow jest to run with typescript
- Add test ignore rule for dist/node-modules 
- Added rule to TS config to allow importing ts extensions
- Adjused import types for audio manager/test file to be compatible with TS